### PR TITLE
Disable accordion for national section

### DIFF
--- a/index.php
+++ b/index.php
@@ -55,6 +55,9 @@
 			$response = preg_replace('/<p>Resultados.+?<\/p>/', '', $response); // we already know/show this one
 			$response = preg_replace('/(?<=class=")table/', 'table table-hover table-condensed', $response); // fancier table
 			$response = preg_replace('/<script>.+?<\/script>/', '', $response); // chau js call
+			$response = preg_replace('/<button.+?<\/button>/', '', $response); // chau botón de imprimir, we love trees
+			$response = preg_replace('/collapse/', '', $response); // chau nacional oculto
+			$response = preg_replace('/accordion-heading/', 'hidden', $response); // chau accordion nacional
 		} else {
 			$hascode = false;
 			$badcode = true;


### PR DESCRIPTION
When there are movements inside the country the response brings them collapsed inside an accordion. Even though it could be enabled using Bootstrap, it shouldn't be there in the first place, so this code disables it (and the disfunctional "print" button too)
